### PR TITLE
Fix logger default level expression

### DIFF
--- a/app/utils/logger.ts
+++ b/app/utils/logger.ts
@@ -11,7 +11,8 @@ interface Logger {
   setLevel: (level: DebugLevel) => void;
 }
 
-let currentLevel: DebugLevel = import.meta.env.VITE_LOG_LEVEL ?? import.meta.env.DEV ? 'debug' : 'info';
+let currentLevel: DebugLevel =
+  import.meta.env.VITE_LOG_LEVEL ?? (import.meta.env.DEV ? 'debug' : 'info');
 
 const isWorker = 'HTMLRewriter' in globalThis;
 const supportsColor = !isWorker;


### PR DESCRIPTION
## Summary
- correct operator precedence for computing default log level

## Testing
- `pnpm test` *(fails: Error when performing request to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_688730c9e1288331ae8b086732152365