### PR TITLE
Add customizable assistant personality

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -7,6 +7,7 @@ import { cssTransition, toast, ToastContainer } from 'react-toastify';
 import { useMessageParser, usePromptEnhancer, useShortcuts, useSnapScroll } from '~/lib/hooks';
 import { useChatHistory } from '~/lib/persistence';
 import { chatStore } from '~/lib/stores/chat';
+import { personalityStore } from '~/lib/stores/personality';
 import { workbenchStore } from '~/lib/stores/workbench';
 import { fileModificationsToHTML } from '~/utils/diff';
 import { cubicEasingFn } from '~/utils/easings';
@@ -75,8 +76,11 @@ export const ChatImpl = memo(({ initialMessages, storeMessageHistory }: ChatProp
 
   const [animationScope, animate] = useAnimate();
 
+  const personality = useStore(personalityStore);
+
   const { messages, isLoading, input, handleInputChange, setInput, stop, append } = useChat({
     api: '/api/chat',
+    body: { systemPrompt: personality || undefined },
     onError: (error) => {
       logger.error('Request failed\n\n', error);
       toast.error('There was an error processing your request');

--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -4,6 +4,7 @@ import { toast } from 'react-toastify';
 import { Dialog, DialogButton, DialogDescription, DialogRoot, DialogTitle } from '~/components/ui/Dialog';
 import { IconButton } from '~/components/ui/IconButton';
 import { ThemeSwitch } from '~/components/ui/ThemeSwitch';
+import { PersonalityDialog } from './PersonalityDialog.client';
 import { db, deleteById, getAll, chatId, type ChatHistoryItem } from '~/lib/persistence';
 import { cubicEasingFn } from '~/utils/easings';
 import { logger } from '~/utils/logger';
@@ -38,6 +39,7 @@ export function Menu() {
   const [list, setList] = useState<ChatHistoryItem[]>([]);
   const [open, setOpen] = useState(false);
   const [dialogContent, setDialogContent] = useState<DialogContent>(null);
+  const [personalityOpen, setPersonalityOpen] = useState(false);
 
   const loadEntries = useCallback(() => {
     if (db) {
@@ -163,9 +165,15 @@ export function Menu() {
             </Dialog>
           </DialogRoot>
         </div>
-        <div className="flex items-center border-t border-bolt-elements-borderColor p-4">
+        <div className="flex items-center border-t border-bolt-elements-borderColor p-4 gap-2">
+          <IconButton
+            icon="i-ph:smiley"
+            title="Edit Personality"
+            onClick={() => setPersonalityOpen(true)}
+          />
           <ThemeSwitch className="ml-auto" />
         </div>
+        <PersonalityDialog open={personalityOpen} onOpenChange={setPersonalityOpen} />
       </div>
     </motion.div>
   );

--- a/app/components/sidebar/PersonalityDialog.client.tsx
+++ b/app/components/sidebar/PersonalityDialog.client.tsx
@@ -1,0 +1,45 @@
+import { useStore } from '@nanostores/react';
+import { useState } from 'react';
+import { Dialog, DialogButton, DialogDescription, DialogRoot, DialogTitle } from '~/components/ui/Dialog';
+import { IconButton } from '~/components/ui/IconButton';
+import { personalityStore, setPersonality } from '~/lib/stores/personality';
+
+interface PersonalityDialogProps {
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+}
+
+export function PersonalityDialog({ open, onOpenChange }: PersonalityDialogProps) {
+  const personality = useStore(personalityStore);
+  const [value, setValue] = useState(personality);
+
+  return (
+    <DialogRoot open={open}>
+      <Dialog onBackdrop={() => onOpenChange(false)} onClose={() => onOpenChange(false)}>
+        <DialogTitle>Assistant Personality</DialogTitle>
+        <DialogDescription asChild>
+          <textarea
+            className="w-full h-40 p-2 border border-bolt-elements-borderColor bg-bolt-elements-background-depth-1 text-bolt-elements-textPrimary"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="Enter system prompt to customize the assistant"
+          />
+        </DialogDescription>
+        <div className="px-5 pb-4 bg-bolt-elements-background-depth-2 flex gap-2 justify-end">
+          <DialogButton type="secondary" onClick={() => onOpenChange(false)}>
+            Cancel
+          </DialogButton>
+          <DialogButton
+            type="primary"
+            onClick={() => {
+              setPersonality(value);
+              onOpenChange(false);
+            }}
+          >
+            Save
+          </DialogButton>
+        </div>
+      </Dialog>
+    </DialogRoot>
+  );
+}

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -21,10 +21,15 @@ export type Messages = Message[];
 
 export type StreamingOptions = Omit<Parameters<typeof _streamText>[0], 'model'>;
 
-export function streamText(messages: Messages, env: Env, options?: StreamingOptions) {
+export function streamText(
+  messages: Messages,
+  env: Env,
+  options?: StreamingOptions,
+  systemPrompt?: string,
+) {
   return _streamText({
     model: getAnthropicModel(getAPIKey(env)),
-    system: getSystemPrompt(),
+    system: systemPrompt ?? getSystemPrompt(),
     maxTokens: MAX_TOKENS,
     headers: {
       'anthropic-beta': 'max-tokens-3-5-sonnet-2024-07-15',

--- a/app/lib/stores/personality.ts
+++ b/app/lib/stores/personality.ts
@@ -1,0 +1,21 @@
+import { atom } from 'nanostores';
+
+export const kPersonality = 'bolt_personality';
+
+function init() {
+  if (!import.meta.env.SSR) {
+    return localStorage.getItem(kPersonality) ?? '';
+  }
+
+  return '';
+}
+
+export const personalityStore = atom<string>(init());
+
+export function setPersonality(prompt: string) {
+  personalityStore.set(prompt);
+
+  if (!import.meta.env.SSR) {
+    localStorage.setItem(kPersonality, prompt);
+  }
+}

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -9,7 +9,10 @@ export async function action(args: ActionFunctionArgs) {
 }
 
 async function chatAction({ context, request }: ActionFunctionArgs) {
-  const { messages } = await request.json<{ messages: Messages }>();
+  const { messages, systemPrompt } = await request.json<{
+    messages: Messages;
+    systemPrompt?: string;
+  }>();
 
   const stream = new SwitchableStream();
 
@@ -32,13 +35,23 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
         messages.push({ role: 'assistant', content });
         messages.push({ role: 'user', content: CONTINUE_PROMPT });
 
-        const result = await streamText(messages, context.cloudflare.env, options);
+        const result = await streamText(
+          messages,
+          context.cloudflare.env,
+          options,
+          systemPrompt,
+        );
 
         return stream.switchSource(result.toAIStream());
       },
     };
 
-    const result = await streamText(messages, context.cloudflare.env, options);
+    const result = await streamText(
+      messages,
+      context.cloudflare.env,
+      options,
+      systemPrompt,
+    );
 
     stream.switchSource(result.toAIStream());
 

--- a/app/routes/api.enhancer.ts
+++ b/app/routes/api.enhancer.ts
@@ -30,6 +30,8 @@ async function enhancerAction({ context, request }: ActionFunctionArgs) {
         },
       ],
       context.cloudflare.env,
+      undefined,
+      undefined,
     );
 
     const transformStream = new TransformStream({


### PR DESCRIPTION
## Summary
- add `personalityStore` to persist custom system prompts
- expose personality editing dialog in the sidebar
- send custom system prompt to API
- allow `streamText` to accept custom system prompts

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688735395f5883319a64885b756cd389